### PR TITLE
Change label for goals nomination

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -13,6 +13,7 @@ message_on_remove = "goals#{number}'s nomination has been removed. Thanks all fo
 message_on_close = "goals#{number} has been closed. Thanks for participating!"
 message_on_reopen = "goals#{number} has been reopened. Pinging @*T-types*."
 
+
 [notify-zulip."C-goal-proposal"]
 zulip_stream = 546987 # #goals/proposed
 topic = "goals#{number}: {title}"
@@ -21,16 +22,18 @@ New goal proposal: "{title}" (goals#{number}).
 
 cc {recipients}
 """
-github_comment = "A [zulip topic]({zulip_topic_url}) was opened to discuss this issue."
-message_on_close = "goals#{number} has been merged or closed. Thanks for participating!"
+github_comment = "A [#goals/proposed topic]({zulip_topic_url}) was opened to discuss this issue."
+message_on_close = "goals#{number} has been resolved. Thanks for participating!"
 
-[notify-zulip."C-goals-meta"]
+
+[notify-zulip."I-goals-nominated"]
 zulip_stream = 478266 # #goals/meta
 topic = "goals#{number}: {title}"
 message_on_add = """\
-Nominated meta-issue: "{title}" (goals#{number}).
+Nominated issue: "{title}" (goals#{number}).
 
 cc {recipients}
 """
-github_comment = "A [zulip topic]({zulip_topic_url}) was opened to discuss this issue."
-message_on_close = "goals#{number} has been closed. Thanks for participating!"
+github_comment = "A [#goals/meta topic]({zulip_topic_url}) was opened to discuss this issue."
+message_on_close = "goals#{number} has been resolved. Thanks for participating!"
+message_on_reopen = "@*T-goals*, goals#{number} has been reopened."


### PR DESCRIPTION
Use `I-goals-nominated` instead of `C-goals-meta` because not every meta issue needs a topic, and non-meta issues may need a meta discussion